### PR TITLE
fix :Remove unique constraint from project name in database schema

### DIFF
--- a/database/migrations/2025_01_18_170819_remove_unique_constraint_from_projects_name.php
+++ b/database/migrations/2025_01_18_170819_remove_unique_constraint_from_projects_name.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->dropUnique(['name']);
+        });
+    }
+};


### PR DESCRIPTION
Project names should not be made unique:

Imagine 2 different users, each having a blog attached to their website, and wanting to track analytics for the blog separately in it's own project.  Each user could expect to be able to name this project simply 'Blog' on Panalyse.

This PR adds a new migration file to remove the unique constraint on the name column of the projects table to address this issue.