### PR TITLE
refactor: update faker syntax to use fake() helper

### DIFF
--- a/database/factories/PageFactory.php
+++ b/database/factories/PageFactory.php
@@ -21,8 +21,8 @@ final class PageFactory extends Factory
     {
         return [
             'project_id' => Project::factory(),
-            'path' => $this->faker->slug,
-            'bucket' => $this->faker->date,
+            'path' => fake()->slug,
+            'bucket' => fake()->date,
             'views' => 0,
             'average_time' => 0,
         ];

--- a/database/factories/ProjectFactory.php
+++ b/database/factories/ProjectFactory.php
@@ -21,7 +21,7 @@ final class ProjectFactory extends Factory
     {
         return [
             'user_id' => User::factory(),
-            'name' => $this->faker->name(),
+            'name' => fake()->name(),
         ];
     }
 }


### PR DESCRIPTION
refactor: update faker syntax to use fake() helper

Replace $this->faker with fake() helper to align with Laravel conventions

- Updates factories to use Laravel's global `fake()` helper
- Changes `$this->faker` instances to `fake()`
