### PR TITLE
chore(gitignore): add package-lock.json file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ yarn-error.log
 /.nova
 /.vscode
 /.zed
+package-lock.json


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [ ] New Feature
- [x] Chore

### Description:

It adds the package-lock.json to the .gitignore
