### PR TITLE
Ignore form request for some arch tests

### DIFF
--- a/tests/Feature/Http/Api/ActivityControllerTest.php
+++ b/tests/Feature/Http/Api/ActivityControllerTest.php
@@ -7,8 +7,6 @@ use App\Jobs\IngestActivity;
 use App\Models\Project;
 use Illuminate\Support\Facades\Queue;
 
-beforeEach()->only();
-
 it('can create an activity', function () {
     // Arrange...
     Queue::fake([IngestActivity::class]);

--- a/tests/Unit/ArchTest.php
+++ b/tests/Unit/ArchTest.php
@@ -17,6 +17,7 @@ arch('avoid mutation')
     ->classes()
     ->toBeReadonly()
     ->ignoring([
+        'App\Http\Requests',
         'App\Exceptions',
         'App\Jobs',
         'App\Models',
@@ -29,6 +30,7 @@ arch('avoid inheritance')
     ->classes()
     ->toExtendNothing()
     ->ignoring([
+        'App\Http\Requests',
         'App\Models',
         'App\Exceptions',
         'App\Jobs',


### PR DESCRIPTION
This PR makes the architecture rules pass, because they need to extend Form Requests