### PR TITLE
test: add HTML coverage report configuration to PHPUnit

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -30,4 +30,9 @@
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
     </php>
+    <coverage>
+        <report>
+            <html outputDirectory="storage/logs/coverage"/>
+        </report>
+    </coverage>
 </phpunit>

--- a/tests/Unit/ArchTest.php
+++ b/tests/Unit/ArchTest.php
@@ -20,6 +20,7 @@ arch('avoid mutation')
         'App\Exceptions',
         'App\Jobs',
         'App\Models',
+        'App\Events',
         'App\Providers',
         'App\Services',
     ]);


### PR DESCRIPTION
Enable HTML coverage reporting by specifying an output directory in `phpunit.xml`. The reports will be stored in `storage/logs/coverage` for easier access and analysis of test coverage.

<!--
- Fill in the form below correctly. This will help the Panalyse team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

<!-- describe what your PR is solving -->

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
